### PR TITLE
Fix: Correct index.js to properly register App component

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,28 +1,12 @@
-import React from "react"; // Still need React for the component
-import { AppRegistry, View, Text, StyleSheet } from "react-native";
-import { name as appName } from "./app.json";
+import { registerRootComponent } from 'expo';
+import App from './src/App'; // Ensure this path is correct
 
-// Define a dead-simple component inline
-const MinimalAppForIndex = () => (
-  <View style={styles.container}>
-    <Text style={styles.text}>Minimal Index.js Loaded!</Text>
-    <Text style={styles.text}>If you see this, AppRegistry is working.</Text>
-    <Text style={styles.text}>The issue might be with how App.tsx is imported or structured, or a deeper Metro/RN bug.</Text>
-  </View>
-);
+// Polyfills that were previously commented out might still be needed.
+// It's good practice to keep them if they were there for a reason.
+import 'react-native-url-polyfill/auto';
+import 'react-native-gesture-handler'; // Must be at the top (or very early) if used
 
-const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: "#D3D3D3" }, // LightGray
-  text: { fontSize: 16, color: "#000000", textAlign: "center", marginVertical: 8 },
-});
-
-// Register the inline component
-AppRegistry.registerComponent(appName, () => MinimalAppForIndex);
-
-// Comment out original App.tsx import and registration for this test
-// import App from "./src/App";
-// AppRegistry.registerComponent(appName, () => App);
-
-// Comment out polyfills for this minimal test too
-// import 'react-native-url-polyfill/auto';
-// import 'react-native-gesture-handler';
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go,
+// or create a production build, the root component is setup correctly.
+registerRootComponent(App);


### PR DESCRIPTION
Updates index.js to use `registerRootComponent` from `expo` for registering the main App component from `src/App.tsx`.

This change ensures that your application's entry point is correctly configured, resolving the '"main" has not been registered' error. Also re-enables previously commented-out polyfills for `react-native-url-polyfill` and `react-native-gesture-handler`.