### PR TITLE
Fix: Update typescript and @types/react to recommended versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "tailwindcss": "3.3.2",
-    "typescript": "~5.3.3",
-    "@types/react": "~18.2.79"
+    "typescript": "~5.8.3",
+    "@types/react": "~19.0.10"
   },
   "private": true
 }


### PR DESCRIPTION
Updates package.json to align typescript and @types/react with versions suggested by Expo warnings:
- typescript: ~5.3.3 -> ~5.8.3
- @types/react: ~18.2.79 -> ~19.0.10

This is an attempt to resolve persistent dependency conflicts and the '"main" has not been registered' error.