### PR TITLE
Fix: Revert @types/react to v18 compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "^7.20.0",
     "tailwindcss": "3.3.2",
     "typescript": "~5.8.3",
-    "@types/react": "~19.0.10"
+    "@types/react": "~18.2.79"
   },
   "private": true
 }


### PR DESCRIPTION
Reverts @types/react from ~19.0.10 back to ~18.2.79 to ensure compatibility with React 18.2.0 used in your project.

This is to address dependency conflicts that arose when trying to align with Expo's suggestion for React 19 types, which caused issues with react-dom resolution.