### PR TITLE
Fix: Add npm overrides for react-dom to ensure v18.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "typescript": "~5.8.3",
     "@types/react": "~18.2.79"
   },
+  "overrides": {
+    "react-dom": "18.2.0"
+  },
   "private": true
 }


### PR DESCRIPTION
Introduces an `overrides` section in package.json to force any transitive dependency requiring `react-dom` to use version `18.2.0`. This aligns `react-dom` with your project's `react` version (18.2.0) and aims to resolve persistent ERESOLVE errors during `npm install`.