### PR TITLE
To isolate the source of the Babel error ".plugins is not a valid Plu…

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel'],
+    plugins: [],
   };
 };


### PR DESCRIPTION
…gin property", I've temporarily removed the 'nativewind/babel' plugin from the babel.config.js.

You can now test if the project builds successfully without this plugin.
- If it builds, the issue is likely with nativewind/babel or its interaction with the Babel toolchain.
- If it still fails with a similar error, the problem might be more fundamental to the Babel/Expo setup.