### PR TITLE
Fix: Restore NativeWind Babel plugin and refine Tailwind config.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [],
+    plugins: ['nativewind/babel'],
   };
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{js,jsx,ts,tsx}', './App.{js,jsx,ts,tsx}'],
+  content: [
+    './index.{js,jsx,ts,tsx}',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
This commit attempts to resolve the Babel error by:
1. Restoring 'nativewind/babel' to the babel.config.js plugins array.
2. Refining the 'content' paths in tailwind.config.js to accurately reflect the project structure (root index.js and ./src/** for components and screens).

You will test if these changes resolve the Babel build error. If the error persists, further investigation into NativeWind versioning or deeper conflicts will be needed.