### PR TITLE
Fix: Update @babel/core to v7.27.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "~5.8.3"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
+    "@babel/core": "^7.24.0",
     "@types/styled-components-react-native": "^5.2.5",
     "react-native-svg-transformer": "^1.5.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.27.5.tgz#7d0658ec1a8420fc866d1df1b03bea0e79934c82"
   integrity sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.20.0", "@babel/core@^7.21.3", "@babel/core@^7.25.2":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.20.0", "@babel/core@^7.21.3", "@babel/core@^7.24.0", "@babel/core@^7.25.2":
   version "7.27.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.27.4.tgz#cc1fc55d0ce140a1828d1dd2a2eba285adbfb3ce"
   integrity sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==


### PR DESCRIPTION
Continuing to troubleshoot the Babel error: ".plugins is not a valid Plugin property".

This commit explicitly updates @babel/core from ^7.20.0 to v7.27.4 (by specifying ^7.24.0 in yarn add). The hope is that a more recent version of Babel's core library might resolve incompatibilities with the 'nativewind/babel' plugin when used with Expo SDK 53.

NativeWind remains at v4.1.19, and Tailwind CSS at v3.4.17. You will test if this resolves the Babel build error.