### PR TITLE
fix: Correct AIService import path in HairAIScreen

### DIFF
--- a/src/screens/HairAIScreen.js
+++ b/src/screens/HairAIScreen.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, ScrollView, ActivityIndicator, Alert } from 'react-native';
-import { getAIHairstyleAdvice } from '../../services/AIService.js';
+import { getAIHairstyleAdvice } from '../services/AIService.js';
 import theme from '../../styles/theme';
 
 const HairAIScreen = () => {


### PR DESCRIPTION
The import path for AIService.js in HairAIScreen.js was incorrect, causing a module resolution error during bundling. This commit fixes the path from '../../services/AIService.js' to '../services/AIService.js'.