### PR TITLE
fix: Simplify paddingTop in HairAIScreen to debug Platform error

### DIFF
--- a/src/screens/HairAIScreen.js
+++ b/src/screens/HairAIScreen.js
@@ -105,7 +105,7 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     backgroundColor: theme.colors.background,
     paddingHorizontal: theme.spacing.md,
-    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight + theme.spacing.md : theme.spacing.lg,
+    paddingTop: theme.spacing.lg,
     paddingBottom: theme.spacing.lg,
   },
   title: {


### PR DESCRIPTION
Temporarily changed paddingTop in HairAIScreen's container style to a static value. This is to diagnose a runtime error "ReferenceError: Property 'Platform' doesn't exist" by avoiding early access to Platform.OS and StatusBar.currentHeight during StyleSheet creation.