### PR TITLE
Okay, I've temporarily commented out the import of the `Platform` mod…

### DIFF
--- a/src/screens/HairAIScreen.js
+++ b/src/screens/HairAIScreen.js
@@ -9,7 +9,7 @@ import {
   ActivityIndicator,
   Alert,
   StatusBar,
-  Platform
+  // Platform // Commented out
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { getAIHairstyleAdvice } from '../services/AIService.js';


### PR DESCRIPTION
…ule in `src/screens/HairAIScreen.js`. This is a diagnostic step to help determine if the import itself is causing the runtime error: "ReferenceError: Property 'Platform' doesn't exist".