### PR TITLE
Update SQL scripts for DB tables and storage policies

### DIFF
--- a/sql/01_create_coloring_recipes.sql
+++ b/sql/01_create_coloring_recipes.sql
@@ -1,0 +1,66 @@
+-- File: sql/01_create_coloring_recipes.sql
+-- Adjustments for existing public.coloring_recipes table.
+-- This script primarily ensures RLS, policies, and triggers are applied.
+
+-- The table structure provided by the user:
+-- CREATE TABLE public.coloring_recipes (
+--   id uuid NOT NULL DEFAULT uuid_generate_v4(),
+--   name text NOT NULL,
+--   ingredients jsonb NOT NULL,
+--   instructions text NOT NULL,
+--   description text,
+--   image_url text,
+--   created_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+--   updated_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+--   CONSTRAINT coloring_recipes_pkey PRIMARY KEY (id)
+-- );
+
+-- Ensure the table exists (idempotent, matching user's schema for key parts)
+CREATE TABLE IF NOT EXISTS public.coloring_recipes (
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    name TEXT NOT NULL,
+    ingredients JSONB NOT NULL,
+    instructions TEXT NOT NULL,
+    description TEXT,
+    image_url TEXT,
+    -- Removed category, preparation_time_minutes, application_time_minutes
+    created_at TIMESTAMPTZ DEFAULT timezone('utc'::text, now()) NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Enable Row Level Security if not already enabled
+-- Note: Supabase UI might show this as enabled by default on new tables.
+-- This command ensures it is explicitly set.
+ALTER TABLE public.coloring_recipes ENABLE ROW LEVEL SECURITY;
+
+-- Policies for coloring_recipes:
+-- Making recipes publicly readable by anyone (authenticated or not).
+DROP POLICY IF EXISTS "Allow public read access on coloring_recipes" ON public.coloring_recipes;
+CREATE POLICY "Allow public read access on coloring_recipes"
+    ON public.coloring_recipes
+    FOR SELECT
+    USING (true);
+
+-- Admin/developer responsibility for insert/update/delete is assumed for now.
+-- If end-users were to submit recipes, more granular policies would be needed.
+
+COMMENT ON TABLE public.coloring_recipes IS 'Stores natural hair coloring recipes, including ingredients, instructions, and other details. Schema adjusted to match existing structure.';
+COMMENT ON COLUMN public.coloring_recipes.ingredients IS 'JSONB containing recipe ingredients and quantities.';
+-- Removed comment for non-existent 'category' column
+
+-- Trigger to update 'updated_at' timestamp
+-- This function might already exist if created by another script.
+CREATE OR REPLACE FUNCTION public.handle_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = timezone('utc'::text, now());
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply the trigger to coloring_recipes table
+DROP TRIGGER IF EXISTS on_coloring_recipes_updated ON public.coloring_recipes;
+CREATE TRIGGER on_coloring_recipes_updated
+    BEFORE UPDATE ON public.coloring_recipes
+    FOR EACH ROW
+    EXECUTE FUNCTION public.handle_updated_at();

--- a/sql/02_create_progress_log.sql
+++ b/sql/02_create_progress_log.sql
@@ -1,0 +1,80 @@
+-- File: sql/02_create_progress_log.sql
+-- Adjustments for existing public.progress_log table.
+-- This script primarily ensures RLS, policies, and triggers are applied.
+
+-- The table structure provided by the user:
+-- CREATE TABLE public.progress_log (
+--   id uuid NOT NULL DEFAULT uuid_generate_v4(),
+--   user_id uuid NOT NULL,
+--   log_date date NOT NULL,
+--   notes text NOT NULL,
+--   image_url text,
+--   created_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+--   updated_at timestamp with time zone NOT NULL DEFAULT timezone('utc'::text, now()),
+--   CONSTRAINT progress_log_pkey PRIMARY KEY (id),
+--   CONSTRAINT progress_log_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id)
+-- );
+
+-- Ensure the table exists (idempotent, matching user's schema for key parts)
+CREATE TABLE IF NOT EXISTS public.progress_log (
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    log_date DATE NOT NULL, -- Adjusted to DATE as per user schema
+    notes TEXT NOT NULL,
+    image_url TEXT, -- Optional URL to an image associated with the log entry
+    -- Removed tags TEXT[]
+    created_at TIMESTAMPTZ DEFAULT timezone('utc'::text, now()) NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Enable Row Level Security if not already enabled
+ALTER TABLE public.progress_log ENABLE ROW LEVEL SECURITY;
+
+-- Indexes (ensure they are compatible or create if not exists)
+CREATE INDEX IF NOT EXISTS idx_progress_log_user_id ON public.progress_log(user_id);
+CREATE INDEX IF NOT EXISTS idx_progress_log_log_date ON public.progress_log(log_date DESC); -- Index on DATE type is fine
+
+-- RLS Policies for progress_log:
+-- Users can manage their own progress logs.
+
+DROP POLICY IF EXISTS "Allow individual insert access on progress_log" ON public.progress_log;
+CREATE POLICY "Allow individual insert access on progress_log"
+    ON public.progress_log
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Allow individual select access on progress_log" ON public.progress_log;
+CREATE POLICY "Allow individual select access on progress_log"
+    ON public.progress_log
+    FOR SELECT
+    TO authenticated
+    USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Allow individual update access on progress_log" ON public.progress_log;
+CREATE POLICY "Allow individual update access on progress_log"
+    ON public.progress_log
+    FOR UPDATE
+    TO authenticated
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Allow individual delete access on progress_log" ON public.progress_log;
+CREATE POLICY "Allow individual delete access on progress_log"
+    ON public.progress_log
+    FOR DELETE
+    TO authenticated
+    USING (auth.uid() = user_id);
+
+-- Trigger to update 'updated_at' timestamp
+-- Assumes public.handle_updated_at() function is available (created in 01_create_coloring_recipes.sql or similar)
+DROP TRIGGER IF EXISTS on_progress_log_updated ON public.progress_log;
+CREATE TRIGGER on_progress_log_updated
+    BEFORE UPDATE ON public.progress_log
+    FOR EACH ROW
+    EXECUTE FUNCTION public.handle_updated_at();
+
+COMMENT ON TABLE public.progress_log IS 'User-specific logs for tracking haircare journey. Schema adjusted to match existing structure.';
+COMMENT ON COLUMN public.progress_log.user_id IS 'References the user who owns this log entry.';
+-- Removed comment for non-existent 'tags' column
+COMMENT ON COLUMN public.progress_log.log_date IS 'The date the log entry pertains to.';

--- a/sql/03_storage_hair_images_policies.sql
+++ b/sql/03_storage_hair_images_policies.sql
@@ -1,0 +1,98 @@
+-- Supabase Storage Policies for a bucket named 'user_hair_images'
+-- This bucket will store images uploaded by users, organized by user_id.
+
+-- First, ensure the bucket exists. This command is typically run via Supabase Studio UI
+-- or programmatically. If running this SQL directly, you might need to create the bucket manually first
+-- if it doesn't exist, or use a Supabase client library to ensure its creation.
+-- Example: INSERT INTO storage.buckets (id, name, public) VALUES ('user_hair_images', 'user_hair_images', false)
+-- ON CONFLICT (id) DO NOTHING;
+-- For this script, we'll assume the bucket 'user_hair_images' has been created and is NOT public.
+
+-- Policy: Allow authenticated users to list their own folder.
+DROP POLICY IF EXISTS "Allow authenticated user to list own folder" ON storage.objects;
+CREATE POLICY "Allow authenticated user to list own folder"
+    ON storage.objects
+    FOR SELECT
+    TO authenticated
+    USING (bucket_id = 'user_hair_images' AND auth.uid()::text = (storage.foldername(name))[1]);
+
+-- Policy: Allow authenticated users to select/download files from their own folder.
+DROP POLICY IF EXISTS "Allow authenticated user to select own files" ON storage.objects;
+CREATE POLICY "Allow authenticated user to select own files"
+    ON storage.objects
+    FOR SELECT
+    TO authenticated
+    USING (bucket_id = 'user_hair_images' AND auth.uid() = owner); -- Simpler check using owner if files are uploaded with owner set to auth.uid()
+    -- OR more explicitly if using folder structure:
+    -- USING (bucket_id = 'user_hair_images' AND auth.uid()::text = (storage.foldername(name))[1]);
+
+-- Policy: Allow authenticated users to upload files into their own folder.
+-- The folder will be named after their user_id.
+-- Example path: user_id/image_name.jpg
+DROP POLICY IF EXISTS "Allow authenticated user to upload to own folder" ON storage.objects;
+CREATE POLICY "Allow authenticated user to upload to own folder"
+    ON storage.objects
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        bucket_id = 'user_hair_images' AND
+        auth.uid()::text = (storage.foldername(name))[1] AND
+        -- Optionally, restrict file types here. This example allows common image types.
+        -- (lower(storage.extension(name)) IN ('jpg', 'jpeg', 'png', 'gif')) AND -- This requires storage.extension function
+        -- Optionally, restrict file size here (e.g., less than 5MB).
+        -- size < 5 * 1024 * 1024 -- This check is on the metadata, might need a trigger for more robust validation.
+        true -- Placeholder if not adding specific type/size checks in policy directly
+    );
+
+-- Policy: Allow authenticated users to update files in their own folder.
+DROP POLICY IF EXISTS "Allow authenticated user to update own files" ON storage.objects;
+CREATE POLICY "Allow authenticated user to update own files"
+    ON storage.objects
+    FOR UPDATE
+    TO authenticated
+    USING (bucket_id = 'user_hair_images' AND auth.uid() = owner)
+    WITH CHECK (bucket_id = 'user_hair_images' AND auth.uid() = owner);
+    -- OR using folder structure:
+    -- USING (bucket_id = 'user_hair_images' AND auth.uid()::text = (storage.foldername(name))[1])
+    -- WITH CHECK (bucket_id = 'user_hair_images' AND auth.uid()::text = (storage.foldername(name))[1]);
+
+
+-- Policy: Allow authenticated users to delete files from their own folder.
+DROP POLICY IF EXISTS "Allow authenticated user to delete own files" ON storage.objects;
+CREATE POLICY "Allow authenticated user to delete own files"
+    ON storage.objects
+    FOR DELETE
+    TO authenticated
+    USING (bucket_id = 'user_hair_images' AND auth.uid() = owner);
+    -- OR using folder structure:
+    -- USING (bucket_id = 'user_hair_images' AND auth.uid()::text = (storage.foldername(name))[1]);
+
+COMMENT ON POLICY "Allow authenticated user to list own folder" ON storage.objects IS
+'Users can list the contents of their own folder within the user_hair_images bucket.';
+COMMENT ON POLICY "Allow authenticated user to select own files" ON storage.objects IS
+'Users can download/read files they own or that are within their user-specific folder in user_hair_images bucket.';
+COMMENT ON POLICY "Allow authenticated user to upload to own folder" ON storage.objects IS
+'Users can upload new files into their own user-specific folder in user_hair_images bucket. Path must start with their user_id.';
+COMMENT ON POLICY "Allow authenticated user to update own files" ON storage.objects IS
+'Users can update files they own or that are within their user-specific folder in user_hair_images bucket.';
+COMMENT ON POLICY "Allow authenticated user to delete own files" ON storage.objects IS
+'Users can delete files they own or that are within their user-specific folder in user_hair_images bucket.';
+
+-- Note on file type and size restrictions:
+-- While some basic checks can be attempted in policies (like extension), more robust validation
+-- (e.g., checking actual MIME type, more complex size limits based on subscription tier)
+-- is often better handled using Supabase Edge Functions triggered on file upload,
+-- or client-side validation before upload, or a combination.
+-- The `storage.foldername(name)` array access `[1]` assumes the first part of the path is the user_id.
+-- e.g. if name is 'user_uuid/image.png', (storage.foldername(name))[1] is 'user_uuid'.
+-- If name is 'image.png' (uploading to root), (storage.foldername(name)) might be empty or different.
+-- Ensure your client-side upload logic creates paths like 'user_id/filename.ext'.
+-- The `auth.uid() = owner` check is simpler if the `owner` field of storage.objects is reliably set to the uploader's UID.
+-- Supabase client libraries usually handle setting the owner field correctly. Using `owner` is often preferred.
+-- For policies that use `(storage.foldername(name))[1]`, ensure that files are always uploaded into a top-level folder named with the user's UID.
+-- e.g., `client.storage.from('user_hair_images').upload(`${userId}/${fileName}`, file)`
+-- If files can be uploaded without a top-level user ID folder, these policies might be too restrictive or too permissive.
+-- The policies above using `auth.uid() = owner` are generally more robust if your client library sets the owner correctly.
+-- I've included both approaches (folder path check and owner check) as comments for consideration.
+-- For the main policy, I've opted for the `auth.uid() = owner` where it simplifies things, assuming standard client usage.
+-- For upload (INSERT), explicitly checking the path structure `(storage.foldername(name))[1]` is good for enforcement.


### PR DESCRIPTION
- Adjusted `01_create_coloring_recipes.sql` to align with the existing user-provided schema for the `coloring_recipes` table. This primarily involves ensuring RLS, policies, and an `updated_at` trigger are correctly applied without altering existing columns or data types.
- Adjusted `02_create_progress_log.sql` similarly for the `progress_log` table, matching its existing schema and applying RLS, policies, indexes, and an `updated_at` trigger.
- `03_storage_hair_images_policies.sql` for Supabase Storage bucket policies remains largely unchanged as it's independent of these specific table structures but is included for completeness.

These changes ensure the SQL scripts are compatible with the user's current database state and can be applied idempotently.