### PR TITLE
Fix: Add missing typography object to theme.js

### DIFF
--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -37,6 +37,47 @@ const theme = {
     sm: 4,
     md: 8,
     lg: 16,
+  },
+  // Define typography styles combining fonts and fontSizes
+  typography: {
+    h1: {
+      fontFamily: "Poppins-Bold", // from theme.fonts.title
+      fontSize: 32,             // from theme.fontSizes.xxl
+      fontWeight: 'bold',       // Standard bold for h1
+      color: "#F0F0F0",          // from theme.colors.textPrimary
+    },
+    h2: {
+      fontFamily: "Poppins-Bold", // from theme.fonts.title
+      fontSize: 24,             // from theme.fontSizes.xl
+      fontWeight: 'bold',
+      color: "#F0F0F0",
+    },
+    body: {
+      fontFamily: "Open Sans",   // from theme.fonts.body
+      fontSize: 16,             // from theme.fontSizes.md
+      fontWeight: 'normal',
+      color: "#F0F0F0",
+      lineHeight: 24,           // Common line height for body text
+    },
+    label: {
+      fontFamily: "Open Sans",
+      fontSize: 14,             // from theme.fontSizes.sm
+      fontWeight: '600',        // Semi-bold for labels
+      color: "#A0A0A0",          // from theme.colors.textSecondary
+    },
+    button: {
+      fontFamily: "Open Sans",
+      fontSize: 16,             // from theme.fontSizes.md
+      fontWeight: 'bold',
+      color: "#FFFFFF",          // Default for buttons with solid backgrounds
+    },
+    caption: {
+      fontFamily: "Open Sans",
+      fontSize: 12,             // from theme.fontSizes.xs
+      fontWeight: 'normal',
+      color: "#A0A0A0",          // from theme.colors.textSecondary
+    }
+    // Add other typography styles as needed (e.g., subtitle, link)
   }
 };
 


### PR DESCRIPTION
- Added the `typography` object to `src/styles/theme.js` with definitions for `h1`, `h2`, `body`, `label`, `button`, and `caption`.
- This resolves the TypeError "Cannot read property 'h1' of undefined" (and similar errors for other typography styles) that occurred in screens using styled-components that accessed these theme properties (e.g., RoutineScreen, RoutineForm).
- The typography styles were derived from existing `fonts` and `fontSizes` within the theme.