### PR TITLE
Fix: Correct JSX closing tag for StepContainer

### DIFF
--- a/src/screens/RoutineForm.js
+++ b/src/screens/RoutineForm.js
@@ -294,7 +294,7 @@ const RoutineForm = () => {
                 <Text style={styles.buttonText}>Remove Step</Text>
               </TouchableOpacity>
             )}
-          </View>
+          </StepContainer>
         ))}
         <TouchableOpacity style={styles.addStepButton} onPress={addStep}>
           <Text style={styles.buttonText}>+ Add Another Step</Text>


### PR DESCRIPTION
Corrects the closing tag for StepContainer in RoutineForm.js that was causing a JSX syntax error.