### PR TITLE
fix: Add explicit metro and metro-config versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   "devDependencies": {
     "@babel/core": "^7.24.0",
     "@expo/metro-config": "0.19.5",
+    "metro": "0.80.8",
+    "metro-config": "0.80.8",
     "@types/styled-components-react-native": "^5.2.5",
     "react-native-svg-transformer": "^1.5.1"
   },


### PR DESCRIPTION
Added explicit versions for `metro` (0.80.8) and `metro-config` (0.80.8) to devDependencies to attempt to stabilize Metro bundler's internal module resolution for Expo SDK 53.